### PR TITLE
feat: Manifest V3への移行と全体的な機能刷新

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,6 @@ This add-on requests the minimum permissions necessary to function:
 - **`scripting`**: Used to remove the `download` attribute from links on pages you have approved.
 - **`webRequest`**: Used to detect when a page has finished loading to know when to run a script.
 - **`optional_host_permissions`**: Used to **request your permission at runtime** for the sites you add. The add-on has no access to any websites when you first install it.
+
+# Disclaimer
+This software is provided "as is", without warranty of any kind. Use at your own risk. The author is not responsible for any damage or loss resulting from the use of this software.

--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ Are you tired of websites automatically downloading files when you just want a q
 
 # How to Use
 
-[![Image from Gyazo](https://i.gyazo.com/6052f89ebdea8b6e5e17d3292cbb31e7.png)](https://gyazo.com/6052f89ebdea8b6e5e17d3292cbb31e7)
+![Image from Gyazo](https://i.gyazo.com/6052f89ebdea8b6e5e17d3292cbb31e7.png)
 
-1. Navigate to [**`about:addons`**](about:addons) in Firefox, or find "Add-ons and Themes" in the menu.
+1. Navigate to [**`about:addons`**](about:addons) in Firefox, or find **Add-ons and Themes** in the menu.
 2. Find **Force Content Previewer** in your list of extensions and click on it.
-3. Go to the **"Preferences" (設定)** tab to open the settings page.
-4. In the **"Add a new permission" (新しいドメインの権限を追加)** section, enter the URL match pattern for the website you want to enable. (See examples below).
+3. Go to the **Preferences (設定)** tab to open the settings page.
+4. In the **Add a new permission (新しいドメインの権限を追加)** section, enter the URL match pattern for the website you want to enable. (See examples below).
 5. Click the **"Add" (追加)** button and grant the permission when prompted.
-6. Once the domain appears in the **"Permitted Domains" (許可されたドメイン)** list, you're all set!
+6. Once the domain appears in the **Permitted Domains (許可されたドメイン)** list, you're all set!
 
 
 
@@ -36,10 +36,12 @@ The pattern consists of `scheme://host/path`. The `*` acts as a wildcard. Using 
 
 # Installation
 ## From GitHub Releases (Manual Install)
-1. Go to the [**Releases page**](releases/).
-2. Download the latest `.xpi` file.
-3. In Firefox, navigate to [`about:addons`](about:addons).
-4. Drag and drop the downloaded `.xpi` file onto the page to install it.
+1. Go to the [**Releases page**](https://github.com/Whateverayn/Force-Content-Previewer/releases).
+2. Click on the latest `.xpi` file link.
+3. A prompt should appear asking you to add the extension. Simply click **Add** and you're done!
+4. **If the prompt does not appear** and the file downloads to your computer instead, please follow these steps:\
+    a. Navigate to [`about:addons`](about:addons) in Firefox.\
+    b. Drag and drop the downloaded `.xpi` file onto this page to install it.
 
 # Permissions Explained
 This add-on requests the minimum permissions necessary to function:

--- a/README.md
+++ b/README.md
@@ -1,2 +1,50 @@
 # Force-Content-Previewer
-Prevents forced downloads on specified domains and tries to preview content in-browser.
+A Firefox add-on that prevents forced file downloads on specified domains and attempts to preview the content directly in your browser.
+
+# Why You Need This
+Are you tired of websites automatically downloading files when you just want a quick look? This extension is for you. It's especially useful for:
+- **University LMS (Learning Management Systems)**: Instantly view lecture notes, assignments, and syllabi without cluttering your downloads folder.
+
+# Features
+- **Prevents Forced Downloads**: Works by rewriting the `Content-Disposition: attachment` header to `inline`.
+- **Disables download Attribute**: Overrides the `download` attribute on `<a>` tags to prioritize previewing.
+- **Privacy-Focused**: The extension does nothing by default. It only activates on domains you explicitly approve in the options page.
+
+# How to Use
+
+[![Image from Gyazo](https://i.gyazo.com/6052f89ebdea8b6e5e17d3292cbb31e7.png)](https://gyazo.com/6052f89ebdea8b6e5e17d3292cbb31e7)
+
+1. Navigate to [**`about:addons`**](about:addons) in Firefox, or find "Add-ons and Themes" in the menu.
+2. Find **Force Content Previewer** in your list of extensions and click on it.
+3. Go to the **"Preferences" (設定)** tab to open the settings page.
+4. In the **"Add a new permission" (新しいドメインの権限を追加)** section, enter the URL match pattern for the website you want to enable. (See examples below).
+5. Click the **"Add" (追加)** button and grant the permission when prompted.
+6. Once the domain appears in the **"Permitted Domains" (許可されたドメイン)** list, you're all set!
+
+
+
+## Understanding URL Match Patterns
+Here are some common examples to help you get started:
+- **A specific university LMS**:\
+    `*://lms.example.com/*`\
+    This pattern targets only your university's LMS site.
+- **All subdomains of a specific site:**\
+    `*://*.example.com/*`\
+    This will work on `example.com`, `portal.example.com`, etc. The `*` before `example.com` is a wildcard for all subdomains.
+
+The pattern consists of `scheme://host/path`. The `*` acts as a wildcard. Using `*` for the scheme matches both `http` and `https`.
+
+# Installation
+## From GitHub Releases (Manual Install)
+1. Go to the [**Releases page**](releases/).
+2. Download the latest `.xpi` file.
+3. In Firefox, navigate to [`about:addons`](about:addons).
+4. Drag and drop the downloaded `.xpi` file onto the page to install it.
+
+# Permissions Explained
+This add-on requests the minimum permissions necessary to function:
+- **`storage`**: Used to save your list of permitted domains.
+- **`declarativeNetRequest`**: The core feature. Used to rewrite web server response headers to change downloads into previews.
+- **`scripting`**: Used to remove the `download` attribute from links on pages you have approved.
+- **`webRequest`**: Used to detect when a page has finished loading to know when to run a script.
+- **`optional_host_permissions`**: Used to **request your permission at runtime** for the sites you add. The add-on has no access to any websites when you first install it.

--- a/src/background.js
+++ b/src/background.js
@@ -19,27 +19,39 @@
 
 // webリクエストが完了したときに発火するリスナー
 browser.webRequest.onCompleted.addListener(
-    (details) => {
-        // ページ全体の読み込み（main_frame）に限定し、サブコンテンツ（画像等）は無視
-        if (details.type === "main_frame") {
+    async (details) => {
+        // 1. 最低限のチェック：メインフレームで、URLがHTTP/HTTPSであること
+        if (details.type !== "main_frame" || !details.url.startsWith('http')) {
+            return;
+        }
 
-            // このリクエストのURLが、許可されたオリジンに含まれているかチェック
-            browser.permissions.contains({
-                origins: [details.url]
-            }).then(hasPermission => {
+        // 2. 権限があるかチェック
+        const hasPermission = await browser.permissions.contains({
+            origins: [details.url]
+        });
 
-                // 権限がある場合のみcontent_script.jsを注入
-                // V3
-                if (hasPermission) {
-                    browser.scripting.executeScript({
-                        target: { tabId: details.tabId },
-                        files: ["content_script.js"]
-                    });
-                }
+        // 権限がなければ何もしない
+        if (!hasPermission) {
+            return;
+        }
+
+        // 3. スクリプト注入を試み、失敗してもエラーを出さずに握りつぶす
+        try {
+            await browser.scripting.executeScript({
+                target: { tabId: details.tabId },
+                files: ["content_script.js"]
             });
+            // 成功した場合は特に何も出力しない
+
+        } catch (error) {
+            // 失敗した場合、これは「保護されたページ」であると判断する。
+            // 通常のログとして出力し、処理を正常に終了させる。
+            console.log(
+                `This is a protected page, skipping script injection: ${details.url}`
+            );
         }
     },
     {
-        urls: ["<all_urls>"] // 権限のあるページだけに絞られる
+        urls: ["<all_urls>"]
     }
 );

--- a/src/background.js
+++ b/src/background.js
@@ -1,21 +1,21 @@
-function rewriteHeader(details) {
-    for (let header of details.responseHeaders) {
-        const headerName = header.name.toLowerCase();
-        const headerValue = header.value.toLowerCase();
+// function rewriteHeader(details) {
+//     for (let header of details.responseHeaders) {
+//         const headerName = header.name.toLowerCase();
+//         const headerValue = header.value.toLowerCase();
 
-        if (headerName === 'content-disposition' && headerValue.startsWith('attachment')) {
-            header.value = 'inline' + header.value.substring('attachment'.length);
-            break;
-        }
-    }
-    return { responseHeaders: details.responseHeaders };
-}
+//         if (headerName === 'content-disposition' && headerValue.startsWith('attachment')) {
+//             header.value = 'inline' + header.value.substring('attachment'.length);
+//             break;
+//         }
+//     }
+//     return { responseHeaders: details.responseHeaders };
+// }
 
-browser.webRequest.onHeadersReceived.addListener(
-    rewriteHeader,
-    { urls: ["<all_urls>"] },
-    ["blocking", "responseHeaders"]
-);
+// browser.webRequest.onHeadersReceived.addListener(
+//     rewriteHeader,
+//     { urls: ["<all_urls>"] },
+//     ["blocking", "responseHeaders"]
+// );
 
 // webリクエストが完了したときに発火するリスナー
 browser.webRequest.onCompleted.addListener(
@@ -29,9 +29,11 @@ browser.webRequest.onCompleted.addListener(
             }).then(hasPermission => {
 
                 // 権限がある場合のみcontent_script.jsを注入
+                // V3
                 if (hasPermission) {
-                    browser.tabs.executeScript(details.tabId, {
-                        file: "content_script.js"
+                    browser.scripting.executeScript({
+                        target: { tabId: details.tabId },
+                        files: ["content_script.js"]
                     });
                 }
             });

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,20 +1,18 @@
 {
-    "manifest_version": 2,
+    "manifest_version": 3,
     "name": "Force Content Previewer",
-    "version": "1.2.0",
+    "version": "2.0.0",
     "description": "Prevents forced downloads on specified domains and tries to preview content in-browser.",
     "permissions": [
-        "webRequest",
-        "webRequestBlocking",
-        "storage"
+        "storage",
+        "declarativeNetRequest",
+        "scripting"
     ],
-    "optional_permissions": [
-        "<all_urls>"
+    "optional_host_permissions": [
+        "*://*/*"
     ],
     "background": {
-        "scripts": [
-            "background.js"
-        ]
+        "service_worker": "background.js"
     },
     "options_ui": {
         "page": "options.html",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -6,17 +6,19 @@
     "permissions": [
         "storage",
         "declarativeNetRequest",
-        "scripting"
+        "scripting",
+        "webRequest"
     ],
     "optional_host_permissions": [
         "*://*/*"
     ],
     "background": {
-        "service_worker": "background.js"
+        "scripts": [
+            "background.js"
+        ]
     },
     "options_ui": {
-        "page": "options.html",
-        "browser_style": true
+        "page": "options.html"
     },
     "icons": {
         "48": "icon.png"

--- a/src/options.html
+++ b/src/options.html
@@ -5,12 +5,13 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Document</title>
-    <link rel="stylesheet" href="chrome://browser/content/extension.css" />
-    <link rel="stylesheet" href="chrome://browser/content/extension-mac.css" />
     <style>
+        * {
+            font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+        }
+
         body {
-            font-family: sans-serif;
-            max-width: 400px;
+            margin: 2rem;
         }
 
         #new-permission {
@@ -29,6 +30,9 @@
             align-items: center;
             margin-bottom: 4px;
         }
+        :root {
+            color-scheme: dark light;
+        }
     </style>
 </head>
 
@@ -37,6 +41,7 @@
     <ul id="permitted-list"></ul>
     <hr>
     <h3>新しいドメインの権限を追加</h3>
+    <p>例: *://lms.example.com/*</p>
     <div id="new-permission">
         <input type="text" id="new-origin" placeholder="*://*.example.com/*">
         <button id="add">追加</button>

--- a/src/options.js
+++ b/src/options.js
@@ -3,55 +3,89 @@ const newOriginInput = document.getElementById('new-origin');
 const addButton = document.getElementById('add');
 const statusElement = document.getElementById('status');
 
+// ルールIDを管理するためのストレージキー
+const RULE_ID_PREFIX = 'rule_id_for_';
+
 // --- デバッグ用 ---
 console.log('options.js が読み込まれました。');
 
 // 現在許可されているドメインを表示する関数
-function updateUI() {
-    console.log('updateUI() が呼び出されました。');
+async function updateUI() {
     listElement.innerHTML = '';
-    browser.permissions.getAll().then(permissions => {
-        console.log('現在の権限:', permissions.origins); // 現在の権限をログに出力
-        for (const origin of permissions.origins) {
-            // ... (この部分は変更なし)
-            const li = document.createElement('li');
-            const span = document.createElement('span');
-            span.textContent = origin;
-            const removeButton = document.createElement('button');
-            removeButton.textContent = '削除';
-            removeButton.onclick = () => {
-                browser.permissions.remove({ origins: [origin] }).then(removed => {
-                    if (removed) updateUI();
-                });
-            };
-            li.appendChild(span);
-            li.appendChild(removeButton);
-            listElement.appendChild(li);
-        }
-    });
+    const permissions = await browser.permissions.getAll();
+    for (const origin of permissions.origins) {
+        const li = document.createElement('li');
+        const span = document.createElement('span');
+        span.textContent = origin;
+        const removeButton = document.createElement('button');
+        removeButton.textContent = '削除';
+
+        // 削除ボタンのクリック処理
+        removeButton.onclick = async () => {
+            const removed = await browser.permissions.remove({ origins: [origin] });
+            if (removed) {
+                // declarativeNetRequest のルールを削除
+                const storageKey = RULE_ID_PREFIX + origin;
+                const data = await browser.storage.local.get(storageKey);
+                if (data[storageKey]) {
+                    await browser.declarativeNetRequest.updateDynamicRules({
+                        removeRuleIds: [data[storageKey]]
+                    });
+                    await browser.storage.local.remove(storageKey);
+                }
+                updateUI();
+            }
+        };
+
+        li.appendChild(span);
+        li.appendChild(removeButton);
+        listElement.appendChild(li);
+    }
 }
 
 // 新しいドメインの権限を要求する関数
-addButton.addEventListener('click', () => {
+addButton.addEventListener('click', async () => {
     const newOrigin = newOriginInput.value.trim();
     if (!newOrigin) return;
 
-    // try...catchブロックで同期的なエラーを捕まえる
     try {
-        browser.permissions.request({ origins: [newOrigin] })
-            .then(granted => {
-                // この部分は非同期処理の結果を扱う
-                if (granted) {
-                    statusElement.textContent = `「${newOrigin}」への権限が許可されました。`;
-                    newOriginInput.value = '';
-                    updateUI();
-                } else {
-                    statusElement.textContent = `「${neworigin}」への権限が拒否されました。`;
-                }
+        const granted = await browser.permissions.request({ origins: [newOrigin] });
+
+        if (granted) {
+            // ★ declarativeNetRequest のルールを追加 ★
+            const newRuleId = Math.floor(Math.random() * 100000); // シンプルなID生成
+            const domain = newOrigin.split('://')[1].split('/')[0].replace('*.', '');
+            
+            await browser.declarativeNetRequest.updateDynamicRules({
+                addRules: [{
+                    id: newRuleId,
+                    priority: 1,
+                    action: {
+                        type: 'modifyHeaders',
+                        responseHeaders: [{
+                            header: 'Content-Disposition',
+                            operation: 'set',
+                            value: 'inline'
+                        }]
+                    },
+                    condition: {
+                        requestDomains: [domain],
+                        resourceTypes: ["main_frame", "sub_frame"]
+                    }
+                }]
             });
+            
+            // ★ 作成したルールIDを保存 ★
+            await browser.storage.local.set({ [RULE_ID_PREFIX + newOrigin]: newRuleId });
+
+            statusElement.textContent = `「${newOrigin}」への権限が許可されました。`;
+            newOriginInput.value = '';
+            updateUI();
+        } else {
+            statusElement.textContent = `「${newOrigin}」への権限が拒否されました。`;
+        }
     } catch (error) {
-        // 同期的なエラー（書式間違いなど）はこちらでキャッチされる
-        console.error(error); // 自分のデバッグ用にエラー内容はコンソールに出しておく
+        console.error(error);
         statusElement.textContent = `エラー: 書式が正しくありません。例: *://*.example.com/*`;
     }
 


### PR DESCRIPTION
Manifest V2のサポートが段階的に廃止される流れを受け，将来的な互換性を確保するために，Manifest V3への移行を実施

- **`manifest.json`のV3化**
    - `manifest_version`を`3`に更新
    - バックグラウンドスクリプトをService Workerベースに変更 (`background.scripts` → FirefoxのV3実装では`scripts`キーを継続利用)
    - `webRequestBlocking`を廃止し、`declarativeNetRequest`権限に変更
    - スクリプト注入のために`scripting`権限を追加
    - オプションのホスト権限を`optional_host_permissions`キーに移行

- **`background.js`の刷新**
    - ヘッダー書き換え処理を、パフォーマンスに優れた`declarativeNetRequest` APIの動的ルール管理へ移行
    - コンテンツスクリプトの注入を`tabs.executeScript`から`scripting.executeScript`へ変更
    - 保護されたページ（PDFビューワ、`about:`ページ等）でエラーが発生しないよう、`try...catch`による堅牢なエラーハンドリングを実装

- **`options.js`の機能追加**
    - ユーザーがドメインを追加・削除するのに連動して、`declarativeNetRequest`の動的ルールを動的に追加・削除するロジックを実装

- **`README.md`の拡充**
    - 機能、使い方、インストール方法、権限の説明などのドキュメントを作成